### PR TITLE
3.28 Update - New items, currencies, and gem changes

### DIFF
--- a/Racing_Templar321.filter
+++ b/Racing_Templar321.filter
@@ -1,4 +1,4 @@
-#Sovereign Filter by StupidFatHobbit updated 3/30/20 | Delirium League | v3.10.2 | GENERAL VERSION
+#Sovereign Filter by StupidFatHobbit updated 3/6/26 | 3.28 Update | GENERAL VERSION
 #Update Notes: Delirium League Update II: Economy, New Highlights, Uberstrict Improvements
 
 #defaultcolors:
@@ -142,7 +142,7 @@
 #	MinimapIcon 2 Green Triangle
 #Show
 #	Class Gem
-#	BaseType "Animate Guardian" "Cleave" "Determination" "Dread Banner" "Exsanguinate" "Herald of Purity" "Holy Flame Totem" "Intimidating Cry" "Molten Shell" "Perforate" "Pride" "Punishment" "Reckoning" "Shockwave Totem" "Summon Stone Golem" "Sweep" "Vaal Molten Shell" "Vengeance" "Vulnerability" "War Banner" "Added Fire Damage Support" "Bloodlust Support" "Bloodthirst Support" "Brutality Support" "Chance to Bleed Support" "Iron Grip Support" "Maim Support" "Melee Physical Damage Support"
+#	BaseType "Animate Guardian" "Cleave" "Determination" "Dread Banner" "Exsanguinate" "Herald of Purity" "Holy Flame Totem" "Intimidating Cry" "Molten Shell" "Perforate" "Pride" "Punishment" "Reckoning" "Shockwave Totem" "Summon Stone Golem" "Holy Sweep" "Vaal Molten Shell" "Vengeance" "Vulnerability" "War Banner" "Added Fire Damage Support" "Bloodlust Support" "Bloodthirst Support" "Brutality Support" "Chance to Bleed Support" "Iron Grip Support" "Maim Support" "Melee Physical Damage Support"
 #	Quality >= 1
 #	SetBorderColor 255 204 102
 #	SetFontSize 40
@@ -655,7 +655,7 @@ Show
 	
 #####non map races very tryhard do not enable unless you dont intend to map#####
 #Hide
-#	BaseType "Cartographer's Chisel" "Gemcutter's Prism" "Blessed Orb"
+#	BaseType "Gemcutter's Prism" "Blessed Orb"
 #	Class Currency
 #	DisableDropSound
 
@@ -2394,7 +2394,7 @@ Show
 ## Zones ##
 Show
 	Class "Gem"
-	BaseType "Summon Skitterbots" "Herald of Thunder" "Herald of Ash" "Herald of Ice" "Lesser Multiple Projectiles" "Volley Support" "Elemental Focus" "Faster Casting" "Cruelty" "Leap Slam" "Anger" "Determination" "Cremation"
+	BaseType "Summon Skitterbots" "Herald of Thunder" "Herald of Ash" "Herald of Ice" "Multiple Projectiles Support" "Volley Support" "Elemental Focus" "Faster Casting" "Cruelty" "Leap Slam" "Anger" "Determination" "Cremation"
 	SetFontSize 45
 Show
 	Class "Gem"
@@ -2851,7 +2851,7 @@ Show
 	MinimapIcon 0 Red Circle
 	PlayEffect Red
 Show
-	BaseType "Divine Orb" "Orb of Annulment" "Harbinger's Orb" "Ancient Orb"
+	BaseType "Divine Orb" "Orb of Annulment" "Ancient Orb" "Volatile Vaal Orb" "Flesh of Xesht"
 	SetBackgroundColor 240 0 200
 	SetBorderColor 0 0 0
 	SetTextColor 0 0 0
@@ -2860,7 +2860,7 @@ Show
 	MinimapIcon 1 Pink Circle
 	PlayEffect Pink
 Show
-	BaseType "Sextant" "Orb of Horizons" "Exalted Shard" "Cartographer's Seal" "Unshaping Orb"
+	BaseType "Sextant" "Exalted Shard"
 	SetBackgroundColor 200 0 250
 #	SetBackgroundColor 150 0 250
 	SetBorderColor 0 0 0
@@ -2878,7 +2878,7 @@ Show
 	SetFontSize 45
 	MinimapIcon 1 Cyan Circle
 Show
-	BaseType "Orb of Binding" "Engineer's Orb"
+	BaseType "Orb of Binding"
 	SetBackgroundColor 0 225 125
 	SetBorderColor 0 0 0
 	SetTextColor 0 0 0
@@ -2938,7 +2938,7 @@ Show
 	PlayAlertSound 3 100
 	MinimapIcon 2 Green Circle
 Show
-	BaseType "Vaal Orb" "Blessed Orb" "Orb of Fusing" "Cartographer's Chisel"
+	BaseType "Vaal Orb" "Blessed Orb" "Orb of Fusing"
 #	SetBackgroundColor 0 175 0
 	SetBackgroundColor 0 165 0
 	SetBorderColor 0 0 0
@@ -2949,7 +2949,7 @@ Show
 
 #Shards
 Show
-	BaseType "Annulment Shard" "Ancient Shard" "Harbinger's Shard" "Horizon Shard"
+	BaseType "Annulment Shard"
 	SetBackgroundColor 0 150 250
 	SetBorderColor 0 0 0
 	SetTextColor 0 0 0
@@ -2959,14 +2959,6 @@ Show
 Show
 	BaseType "Chaos Shard" "Regal Shard"
 	SetBorderColor 0 200 200
-	SetFontSize 40
-Show
-	BaseType "Engineer's Shard"
-	SetBorderColor 170 158 130
-	SetFontSize 40
-Show
-	BaseType "Binding Shard"
-	SetBorderColor 170 158 130
 	SetFontSize 40
 #Minor Currency, Scrolls, Etc
 Show
@@ -2987,6 +2979,68 @@ Show
 	SetFontSize 38
 	AreaLevel <= 78
 	
+
+#3.28 New Currencies
+Show
+	BaseType "Coin of Knowledge" "Coin of Power" "Coin of Skill" "Coin of Restoration" "Coin of Desecration"
+	Class Currency
+	SetBackgroundColor 0 225 125
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 100
+	MinimapIcon 2 Green Circle
+	PlayEffect Green Temp
+	DisableDropSound
+Show
+	BaseType "Refracting Fog" "Essence of Desolation" "Crystallised Rancour"
+	Class Currency
+	SetBackgroundColor 0 185 185
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 125
+	MinimapIcon 2 Cyan Circle
+	DisableDropSound
+Show
+	BaseType "Sinistral Catalyst" "Dextral Catalyst"
+	Class Currency
+	SetBackgroundColor 0 225 125
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 100
+	MinimapIcon 2 Green Circle
+	PlayEffect Green Temp
+	DisableDropSound
+Show
+	BaseType "Memory of Trauma" "Memory of Reverence" "Memory of Loneliness"
+	Class Currency
+	SetBackgroundColor 0 185 185
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 125
+	MinimapIcon 2 Cyan Circle
+	DisableDropSound
+Show
+	BaseType "Runegraft"
+	Class Currency
+	SetBackgroundColor 170 158 130
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+Show
+	BaseType "Astrolabe"
+	Class Currency
+	SetBackgroundColor 0 225 125
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 100
+	MinimapIcon 2 Green Circle
+	PlayEffect Green Temp
+	DisableDropSound
 #6L Blocks - located up here due to code priority issues. 5L and 6S blocks are in the Sockets section (7)
 #tabula exception so it doesn't show with white bg and top sound
 Show
@@ -4226,12 +4280,6 @@ Show
 #	SetBackgroundColor 0 100 140
 #	SetBorderColor 225 225 225
 #	SetTextColor 225 225 225
-#	SetFontSize 45
-#	MinimapIcon 2 Cyan Raindrop
-#	PlayEffect Cyan Temp
-#Show
-#	BaseType "Time-light Scroll" "Fragmentation Scroll" "Deregulation Scroll" "Electroshock Scroll" "Haemocombustion Scroll" "Specularity Scroll"
-#	SetTextColor 0 200 240
 #	SetFontSize 45
 #	MinimapIcon 2 Cyan Raindrop
 #	PlayEffect Cyan Temp
@@ -6272,7 +6320,7 @@ Show
 	PlayEffect Blue Temp
 #Maximum Tier: Extreme Value only (100c+). White. Mainly HH and mirror cards. Immortal Resolve is usually the low-end cutoff
 Show
-	BaseType "House of Mirrors" "The Doctor" "The Fiend" "Immortal Resolve" "The Demon" "Nook's Crown" "Beauty Through Death" "The Samurai's Eye" "Succor of the Sinless" "The Cheater"
+	BaseType "House of Mirrors" "The Doctor" "The Fiend" "Immortal Resolve" "The Demon" "Nook's Crown" "Beauty Through Death" "The Samurai's Eye" "Succor of the Sinless"
 	SetBackgroundColor 250 250 250
 	SetBorderColor 0 0 0
 	SetTextColor 240 0 240
@@ -6304,7 +6352,7 @@ Show
 	PlayEffect Purple
 #Low Tier: Shit or Very Common Div Cards: No sounds on these, darker blue color. More about removing cards that drop a lot to remove sound spam than removing low value cards. Everything here should be <1 chaos.
 Show
-	BaseType "The Gambler" "The Scholar" "The Lover" "Emperor's Luck" "Flora's Gift" "Her Mask" "The Catalyst" "Destined to Crumble" "The Inoculated" "The Road to Power" "The Sigil" "The Spoiled Prince" "Rain of Chaos" "Thunderous Skies" "The Twins" "Light and Truth" "Prosperity" "The Mercenary" "The Warden" "The Calling" "The Gemcutter" "The Lord in Black" "Struck by Lightning" "The Metalsmith's Gift" "Lantador's Lost Love" "The Scarred Meadow" "The Visionary" "The Incantation" "Dying Anguish" "Cartographer's Delight" "The Pack Leader" "The Gentleman" "The Opulent" "A Mother's Parting Gift" "The Sun" "The Conduit" "The Fox" "The Realm" "The Web" "Turn the Other Cheek" "Lysah's Respite" "The Lich" "The Feast" "The Witch" "Ruthless Ceinture" "The Siren" "Death" "Call to the First Ones" "The Hermit" "The Puzzle" "The Fathomless Depths" "Audacity" "Doedre's Madness" "Rain Tempter" "Anarchy's Price" "The Watcher" "The Coming Storm" "Dark Temptation" "Blazing Fire" "Tranquillity"
+	BaseType "The Gambler" "The Scholar" "The Lover" "Emperor's Luck" "Flora's Gift" "Her Mask" "The Catalyst" "Destined to Crumble" "The Inoculated" "The Road to Power" "The Sigil" "The Spoiled Prince" "Rain of Chaos" "Thunderous Skies" "The Twins" "Light and Truth" "Prosperity" "The Mercenary" "The Warden" "The Calling" "The Gemcutter" "The Lord in Black" "Struck by Lightning" "The Metalsmith's Gift" "Lantador's Lost Love" "The Scarred Meadow" "The Visionary" "The Incantation" "Dying Anguish" "Cartographer's Delight" "The Pack Leader" "The Gentleman" "The Opulent" "A Mother's Parting Gift" "The Sun" "The Conduit" "The Fox" "The Realm" "The Web" "Turn the Other Cheek" "Lysah's Respite" "The Lich" "The Feast" "The Witch" "Ruthless Ceinture" "The Siren" "Death" "Call to the First Ones" "The Hermit" "The Fathomless Depths" "Audacity" "Doedre's Madness" "Rain Tempter" "Anarchy's Price" "The Watcher" "The Coming Storm" "Dark Temptation" "Blazing Fire" "Tranquillity"
 	Class "Divination Card"
 #	SetBackgroundColor 150 200 250
 #	SetBackgroundColor 125 175 225
@@ -8418,7 +8466,7 @@ Show
 ###################################################################################
 #top and rare gems
 Show
-	BaseType "Item Quantity" "Awakened"
+	BaseType "Item Quantity" "Awakened" "Exceptional"
 	Class "Gem"
 	SetBackgroundColor 250 250 250
 	SetBorderColor 0 0 0

--- a/gpAttackSlams.filter
+++ b/gpAttackSlams.filter
@@ -1,4 +1,4 @@
-#Sovereign Filter by StupidFatHobbit updated 4/24/23 | Crucible League | v3.21.1 | GENERAL VERSION
+#Sovereign Filter by StupidFatHobbit updated 3/6/26 | 3.28 Update | GENERAL VERSION
 #Update Notes: Long Overdue Economy Update (Crucible League Update I)
 
 #defaultcolors:
@@ -3929,6 +3929,16 @@ Show
 	DisableDropSound
 
 Show
+	BaseType "Volatile Vaal Orb" "Flesh of Xesht"
+	SetBackgroundColor 240 0 200
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	PlayAlertSound 10 250
+	SetFontSize 45
+	MinimapIcon 1 Pink Circle
+	PlayEffect Pink
+	DisableDropSound
+Show
 	BaseType "Orb of Binding" "Veiled" "Enkindling Orb" "Instilling Orb" 
 	Class Currency
 	SetBackgroundColor 0 225 125
@@ -4005,6 +4015,68 @@ Show
 	SetFontSize 38
 	AreaLevel <= 78
 	
+
+#3.28 New Currencies
+Show
+	BaseType "Coin of Knowledge" "Coin of Power" "Coin of Skill" "Coin of Restoration" "Coin of Desecration"
+	Class Currency
+	SetBackgroundColor 0 225 125
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 100
+	MinimapIcon 2 Green Circle
+	PlayEffect Green Temp
+	DisableDropSound
+Show
+	BaseType "Refracting Fog" "Essence of Desolation" "Crystallised Rancour"
+	Class Currency
+	SetBackgroundColor 0 185 185
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 125
+	MinimapIcon 2 Cyan Circle
+	DisableDropSound
+Show
+	BaseType "Sinistral Catalyst" "Dextral Catalyst"
+	Class Currency
+	SetBackgroundColor 0 225 125
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 100
+	MinimapIcon 2 Green Circle
+	PlayEffect Green Temp
+	DisableDropSound
+Show
+	BaseType "Memory of Trauma" "Memory of Reverence" "Memory of Loneliness"
+	Class Currency
+	SetBackgroundColor 0 185 185
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 125
+	MinimapIcon 2 Cyan Circle
+	DisableDropSound
+Show
+	BaseType "Runegraft"
+	Class Currency
+	SetBackgroundColor 170 158 130
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+Show
+	BaseType "Astrolabe"
+	Class Currency
+	SetBackgroundColor 0 225 125
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 100
+	MinimapIcon 2 Green Circle
+	PlayEffect Green Temp
+	DisableDropSound
 #6L Blocks - located up here due to code priority issues. 5L and 6S blocks are in the Sockets section (7)
 #corrupted catcher
 Show
@@ -5220,15 +5292,6 @@ Show
 	PlayAlertSound 11 200
 	MinimapIcon 1 Cyan Raindrop
 	PlayEffect Cyan Temp
-Show
-	BaseType "Time-light Scroll" "Fragmentation Scroll" "Deregulation Scroll" "Electroshock Scroll" "Haemocombustion Scroll" "Specularity Scroll"
-	SetBackgroundColor 250 40 0
-	SetBorderColor 250 250 250
-	SetTextColor 0 0 0
-	SetFontSize 45
-	PlayAlertSound 2 200
-	MinimapIcon 0 Orange Triangle
-	PlayEffect Orange
 Show
 	BaseType "Facetor's Lens"
 	SetBackgroundColor 0 200 240
@@ -7833,7 +7896,7 @@ Show
 
 #Dogshit Tier: Hidden in all filters, waste of a click to pick up. Same highlight as trash tier. Only the very worst get added here.
 Hide
-	BaseType == "The Carrion Crow" "The Surgeon" "The King's Blade" "The Lunaris Priestess" "The Metalsmith's Gift" "Lantador's Lost Love" "The Scholar" "The Sigil" "The Lover" "The Puzzle" "The Warden" "Rain Tempter" "Rain of Chaos" "Prosperity" "Struck By Lightning" "The Inoculated" "The Opulent" "The Scarred Meadow" "Destined to Crumble" "Thirst for Knowledge" "The Witch" "The Visionary" "The Sword King's Salute" "The Harvester" "Rats" "Might is Right" "The Adventuring Spirit"
+	BaseType == "The Carrion Crow" "The Surgeon" "The King's Blade" "The Lunaris Priestess" "The Metalsmith's Gift" "Lantador's Lost Love" "The Scholar" "The Sigil" "The Lover" "The Warden" "Rain Tempter" "Rain of Chaos" "Prosperity" "Struck By Lightning" "The Inoculated" "The Opulent" "The Scarred Meadow" "Destined to Crumble" "Thirst for Knowledge" "The Witch" "The Visionary" "The Sword King's Salute" "The Harvester" "Rats" "Might is Right" "The Adventuring Spirit"
 	Class "Divination Card"
 	SetBackgroundColor 110 160 210
 	SetBorderColor 0 0 0
@@ -12115,7 +12178,7 @@ Show
 ###################################################################################
 #top and rare gems
 Show
-	BaseType "Item Quantity" "Awakened"
+	BaseType "Item Quantity" "Awakened" "Exceptional"
 	Class "Gem"
 	SetBackgroundColor 250 250 250
 	SetBorderColor 0 0 0

--- a/gpAttackSpecThrow.filter
+++ b/gpAttackSpecThrow.filter
@@ -1,4 +1,4 @@
-#Sovereign Filter by StupidFatHobbit updated 4/24/23 | Crucible League | v3.21.1 | GENERAL VERSION
+#Sovereign Filter by StupidFatHobbit updated 3/6/26 | 3.28 Update | GENERAL VERSION
 #Update Notes: Long Overdue Economy Update (Crucible League Update I)
 
 #defaultcolors:
@@ -3831,6 +3831,16 @@ Show
 	DisableDropSound
 
 Show
+	BaseType "Volatile Vaal Orb" "Flesh of Xesht"
+	SetBackgroundColor 240 0 200
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	PlayAlertSound 10 250
+	SetFontSize 45
+	MinimapIcon 1 Pink Circle
+	PlayEffect Pink
+	DisableDropSound
+Show
 	BaseType "Orb of Binding" "Veiled" "Enkindling Orb" "Instilling Orb" "Oil Extractor"
 	Class Currency
 	SetBackgroundColor 0 225 125
@@ -3907,6 +3917,68 @@ Show
 	SetFontSize 38
 	AreaLevel <= 78
 	
+
+#3.28 New Currencies
+Show
+	BaseType "Coin of Knowledge" "Coin of Power" "Coin of Skill" "Coin of Restoration" "Coin of Desecration"
+	Class Currency
+	SetBackgroundColor 0 225 125
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 100
+	MinimapIcon 2 Green Circle
+	PlayEffect Green Temp
+	DisableDropSound
+Show
+	BaseType "Refracting Fog" "Essence of Desolation" "Crystallised Rancour"
+	Class Currency
+	SetBackgroundColor 0 185 185
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 125
+	MinimapIcon 2 Cyan Circle
+	DisableDropSound
+Show
+	BaseType "Sinistral Catalyst" "Dextral Catalyst"
+	Class Currency
+	SetBackgroundColor 0 225 125
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 100
+	MinimapIcon 2 Green Circle
+	PlayEffect Green Temp
+	DisableDropSound
+Show
+	BaseType "Memory of Trauma" "Memory of Reverence" "Memory of Loneliness"
+	Class Currency
+	SetBackgroundColor 0 185 185
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 125
+	MinimapIcon 2 Cyan Circle
+	DisableDropSound
+Show
+	BaseType "Runegraft"
+	Class Currency
+	SetBackgroundColor 170 158 130
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+Show
+	BaseType "Astrolabe"
+	Class Currency
+	SetBackgroundColor 0 225 125
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 100
+	MinimapIcon 2 Green Circle
+	PlayEffect Green Temp
+	DisableDropSound
 #6L Blocks - located up here due to code priority issues. 5L and 6S blocks are in the Sockets section (7)
 #corrupted catcher
 Show
@@ -5122,15 +5194,6 @@ Show
 	PlayAlertSound 11 200
 	MinimapIcon 1 Cyan Raindrop
 	PlayEffect Cyan Temp
-Show
-	BaseType "Time-light Scroll" "Fragmentation Scroll" "Deregulation Scroll" "Electroshock Scroll" "Haemocombustion Scroll" "Specularity Scroll"
-	SetBackgroundColor 250 40 0
-	SetBorderColor 250 250 250
-	SetTextColor 0 0 0
-	SetFontSize 45
-	PlayAlertSound 2 200
-	MinimapIcon 0 Orange Triangle
-	PlayEffect Orange
 Show
 	BaseType "Facetor's Lens"
 	SetBackgroundColor 0 200 240
@@ -7669,7 +7732,7 @@ Show
 
 #Maximum Tier - 100c+. White.
 Show
-	BaseType == "The Doctor" "The Fiend" "House of Mirrors" "Immortal Resolve" "The Demon" "Beauty Through Death" "The Cheater" "Unrequited Love" "Love Through Ice" "The Apothecary" "The Shieldbearer" "Choking Guilt" "The Price of Devotion" "The Insane Cat" "Brother's Gift" "The Immortal" "The Sephirot"
+	BaseType == "The Doctor" "The Fiend" "House of Mirrors" "Immortal Resolve" "The Demon" "Beauty Through Death" "Unrequited Love" "Love Through Ice" "The Apothecary" "The Shieldbearer" "Choking Guilt" "The Price of Devotion" "The Insane Cat" "Brother's Gift" "The Immortal" "The Sephirot"
 	SetBackgroundColor 250 250 250
 	SetBorderColor 0 0 0
 	SetTextColor 240 0 240
@@ -7735,7 +7798,7 @@ Show
 
 #Dogshit Tier: Hidden in all filters, waste of a click to pick up. Same highlight as trash tier. Only the very worst get added here.
 Hide
-	BaseType == "The Carrion Crow" "The Surgeon" "The King's Blade" "The Lunaris Priestess" "The Metalsmith's Gift" "Lantador's Lost Love" "The Scholar" "The Sigil" "The Lover" "The Puzzle" "The Warden" "Rain Tempter" "Rain of Chaos" "Prosperity" "Struck By Lightning" "The Inoculated" "The Opulent" "The Scarred Meadow" "Destined to Crumble" "Thirst for Knowledge" "The Witch" "The Visionary" "The Sword King's Salute" "The Harvester" "Rats" "Might is Right" "The Adventuring Spirit"
+	BaseType == "The Carrion Crow" "The Surgeon" "The King's Blade" "The Lunaris Priestess" "The Metalsmith's Gift" "Lantador's Lost Love" "The Scholar" "The Sigil" "The Lover" "The Warden" "Rain Tempter" "Rain of Chaos" "Prosperity" "Struck By Lightning" "The Inoculated" "The Opulent" "The Scarred Meadow" "Destined to Crumble" "Thirst for Knowledge" "The Witch" "The Visionary" "The Sword King's Salute" "The Harvester" "Rats" "Might is Right" "The Adventuring Spirit"
 	Class "Divination Card"
 	SetBackgroundColor 110 160 210
 	SetBorderColor 0 0 0
@@ -12018,7 +12081,7 @@ Show
 ###################################################################################
 #top and rare gems
 Show
-	BaseType "Item Quantity" "Awakened"
+	BaseType "Item Quantity" "Awakened" "Exceptional"
 	Class "Gem"
 	SetBackgroundColor 250 250 250
 	SetBorderColor 0 0 0

--- a/gpCasterLeapSlam.filter
+++ b/gpCasterLeapSlam.filter
@@ -1,4 +1,4 @@
-#Sovereign Filter by StupidFatHobbit updated 4/24/23 | Crucible League | v3.21.1 | GENERAL VERSION
+#Sovereign Filter by StupidFatHobbit updated 3/6/26 | 3.28 Update | GENERAL VERSION
 #Update Notes: Long Overdue Economy Update (Crucible League Update I)
 
 #defaultcolors:
@@ -2874,7 +2874,7 @@ Show
 #Show 
 #	Quality >= 5
 #	Class "Gem"
-#	BaseType == "Absolution" "Added Fire Damage Support" "Animate Guardian" "Animate Weapon" "Bear Trap" "Blade Blast" "Blade Flurry" "Bladefall" "Blood Rage" "Bloodlust Support" "Bloodthirst Support" "Boneshatter" "Brutality Support" "Chance to Bleed Support" "Cleave" "Corrupting Cry Support" "Corrupting Fever" "Cyclone" "Defiance Banner" "Determination" "Divine Ire" "Double Strike" "Dread Banner" "Ethereal Knives" "Explosive Trap" "Exsanguinate" "Glacial Cascade" "Herald of Agony" "Herald of Purity" "Holy Flame Totem" "Hydrosphere" "Impale Support" "Intimidating Cry" "Iron Grip Support" "Lacerate" "Lancing Steel" "Maim Support" "Melee Physical Damage Support" "Molten Shell" "Penance Brand" "Perforate" "Phase Run" "Physical to Lightning Support" "Pride" "Puncture" "Punishment" "Purifying Flame" "Reap" "Swordstorm" "Glacial Shield Swipe" "Seismic Trap" "Shattering Steel" "Shield Charge" "Shield Crush" "Shockwave Totem" "Shrapnel Ballista" "Snipe" "Spectral Shield Throw" "Split Arrow" "Splitting Steel" "Storm Burst" "Summon Carrion Golem" "Summon Reaper" "Summon Stone Golem" "Sweep" "Tornado" "Trauma Support" "Unearth" "Vaal Absolution" "Vaal Animate Weapon" "Vaal Blade Flurry" "Vaal Blade Vortex" "Vaal Cleave" "Vaal Cyclone" "Vaal Double Strike" "Vaal Molten Shell" "Vaal Reap" "Crushing Fist" "Vicious Projectiles Support" "Void Sphere" "Vulnerability" "War Banner" "Wave of Conviction" "Withering Touch Support"
+#	BaseType == "Absolution" "Added Fire Damage Support" "Animate Guardian" "Animate Weapon" "Bear Trap" "Blade Blast" "Blade Flurry" "Bladefall" "Blood Rage" "Bloodlust Support" "Bloodthirst Support" "Boneshatter" "Brutality Support" "Chance to Bleed Support" "Cleave" "Corrupting Cry Support" "Corrupting Fever" "Cyclone" "Defiance Banner" "Determination" "Divine Ire" "Double Strike" "Dread Banner" "Ethereal Knives" "Explosive Trap" "Exsanguinate" "Glacial Cascade" "Herald of Agony" "Herald of Purity" "Holy Flame Totem" "Hydrosphere" "Impale Support" "Intimidating Cry" "Iron Grip Support" "Lacerate" "Lancing Steel" "Maim Support" "Melee Physical Damage Support" "Molten Shell" "Penance Brand" "Perforate" "Phase Run" "Physical to Lightning Support" "Pride" "Puncture" "Punishment" "Purifying Flame" "Reap" "Swordstorm" "Glacial Shield Swipe" "Seismic Trap" "Shattering Steel" "Shield Charge" "Shield Crush" "Shockwave Totem" "Shrapnel Ballista" "Snipe" "Spectral Shield Throw" "Split Arrow" "Splitting Steel" "Storm Burst" "Summon Carrion Golem" "Summon Reaper" "Summon Stone Golem" "Holy Sweep" "Tornado" "Trauma Support" "Unearth" "Vaal Absolution" "Vaal Animate Weapon" "Vaal Blade Flurry" "Vaal Blade Vortex" "Vaal Cleave" "Vaal Cyclone" "Vaal Double Strike" "Vaal Molten Shell" "Vaal Reap" "Crushing Fist" "Vicious Projectiles Support" "Void Sphere" "Vulnerability" "War Banner" "Wave of Conviction" "Withering Touch Support"
 #	SetBackgroundColor 180 0 0
 #	SetBorderColor 0 0 0
 #	SetTextColor 0 0 0
@@ -3711,7 +3711,7 @@ Show
 #Show 
 #	Quality >= 5
 #	Class "Gem"
-#	BaseType == "Absolution" "Added Fire Damage Support" "Animate Guardian" "Animate Weapon" "Bear Trap" "Blade Blast" "Blade Flurry" "Bladefall" "Blood Rage" "Bloodlust Support" "Bloodthirst Support" "Boneshatter" "Brutality Support" "Chance to Bleed Support" "Cleave" "Corrupting Cry Support" "Corrupting Fever" "Cyclone" "Defiance Banner" "Determination" "Divine Ire" "Double Strike" "Dread Banner" "Ethereal Knives" "Explosive Trap" "Exsanguinate" "Glacial Cascade" "Herald of Agony" "Herald of Purity" "Holy Flame Totem" "Hydrosphere" "Impale Support" "Intimidating Cry" "Iron Grip Support" "Lacerate" "Lancing Steel" "Maim Support" "Melee Physical Damage Support" "Molten Shell" "Penance Brand" "Perforate" "Phase Run" "Physical to Lightning Support" "Pride" "Puncture" "Punishment" "Purifying Flame" "Reap" "Swordstorm" "Glacial Shield Swipe" "Seismic Trap" "Shattering Steel" "Shield Charge" "Shield Crush" "Shockwave Totem" "Shrapnel Ballista" "Snipe" "Spectral Shield Throw" "Split Arrow" "Splitting Steel" "Storm Burst" "Summon Carrion Golem" "Summon Reaper" "Summon Stone Golem" "Sweep" "Tornado" "Trauma Support" "Unearth" "Vaal Absolution" "Vaal Animate Weapon" "Vaal Blade Flurry" "Vaal Blade Vortex" "Vaal Cleave" "Vaal Cyclone" "Vaal Double Strike" "Vaal Molten Shell" "Vaal Reap" "Crushing Fist" "Vicious Projectiles Support" "Void Sphere" "Vulnerability" "War Banner" "Wave of Conviction" "Withering Touch Support"
+#	BaseType == "Absolution" "Added Fire Damage Support" "Animate Guardian" "Animate Weapon" "Bear Trap" "Blade Blast" "Blade Flurry" "Bladefall" "Blood Rage" "Bloodlust Support" "Bloodthirst Support" "Boneshatter" "Brutality Support" "Chance to Bleed Support" "Cleave" "Corrupting Cry Support" "Corrupting Fever" "Cyclone" "Defiance Banner" "Determination" "Divine Ire" "Double Strike" "Dread Banner" "Ethereal Knives" "Explosive Trap" "Exsanguinate" "Glacial Cascade" "Herald of Agony" "Herald of Purity" "Holy Flame Totem" "Hydrosphere" "Impale Support" "Intimidating Cry" "Iron Grip Support" "Lacerate" "Lancing Steel" "Maim Support" "Melee Physical Damage Support" "Molten Shell" "Penance Brand" "Perforate" "Phase Run" "Physical to Lightning Support" "Pride" "Puncture" "Punishment" "Purifying Flame" "Reap" "Swordstorm" "Glacial Shield Swipe" "Seismic Trap" "Shattering Steel" "Shield Charge" "Shield Crush" "Shockwave Totem" "Shrapnel Ballista" "Snipe" "Spectral Shield Throw" "Split Arrow" "Splitting Steel" "Storm Burst" "Summon Carrion Golem" "Summon Reaper" "Summon Stone Golem" "Holy Sweep" "Tornado" "Trauma Support" "Unearth" "Vaal Absolution" "Vaal Animate Weapon" "Vaal Blade Flurry" "Vaal Blade Vortex" "Vaal Cleave" "Vaal Cyclone" "Vaal Double Strike" "Vaal Molten Shell" "Vaal Reap" "Crushing Fist" "Vicious Projectiles Support" "Void Sphere" "Vulnerability" "War Banner" "Wave of Conviction" "Withering Touch Support"
 #	SetBackgroundColor 180 0 0
 #	SetBorderColor 0 0 0
 #	SetTextColor 0 0 0
@@ -4394,8 +4394,6 @@ Show
 ##################################################
 ########## Section 0A - SSF Overrides ############
 ##################################################
-Hide
-	BaseType "Engineer's Orb" 
 
 #Tainted Currencies
 Show
@@ -4539,7 +4537,7 @@ Show
 	MinimapIcon 2 Blue Circle
 	PlayEffect Blue Temp
 Hide
-	BaseType "Chaos Shard" "Alchemy Shard" "Binding Shard" "Alteration Shard"
+	BaseType "Chaos Shard" "Alchemy Shard" "Alteration Shard"
 	SetBorderColor 0 150 250
 	SetTextColor 0 150 250
 	SetFontSize 42
@@ -4917,6 +4915,16 @@ Show
 	DisableDropSound
 
 Show
+	BaseType "Volatile Vaal Orb" "Flesh of Xesht"
+	SetBackgroundColor 240 0 200
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	PlayAlertSound 10 250
+	SetFontSize 45
+	MinimapIcon 1 Pink Circle
+	PlayEffect Pink
+	DisableDropSound
+Show
 	BaseType "Orb of Binding" "Veiled" "Enkindling Orb" "Instilling Orb" "Oil Extractor"
 	Class "Currency"
 	SetBackgroundColor 0 225 125
@@ -4970,7 +4978,7 @@ Show
 	SetFontSize 40
 
 Show
-	BaseType "Binding Shard" "Alchemy Shard"
+	BaseType "Alchemy Shard"
 	SetBorderColor 170 158 130
 	SetFontSize 40
 
@@ -4993,6 +5001,68 @@ Show
 	SetFontSize 38
 	AreaLevel <= 78
 	
+
+#3.28 New Currencies
+Show
+	BaseType "Coin of Knowledge" "Coin of Power" "Coin of Skill" "Coin of Restoration" "Coin of Desecration"
+	Class Currency
+	SetBackgroundColor 0 225 125
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 100
+	MinimapIcon 2 Green Circle
+	PlayEffect Green Temp
+	DisableDropSound
+Show
+	BaseType "Refracting Fog" "Essence of Desolation" "Crystallised Rancour"
+	Class Currency
+	SetBackgroundColor 0 185 185
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 125
+	MinimapIcon 2 Cyan Circle
+	DisableDropSound
+Show
+	BaseType "Sinistral Catalyst" "Dextral Catalyst"
+	Class Currency
+	SetBackgroundColor 0 225 125
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 100
+	MinimapIcon 2 Green Circle
+	PlayEffect Green Temp
+	DisableDropSound
+Show
+	BaseType "Memory of Trauma" "Memory of Reverence" "Memory of Loneliness"
+	Class Currency
+	SetBackgroundColor 0 185 185
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 125
+	MinimapIcon 2 Cyan Circle
+	DisableDropSound
+Show
+	BaseType "Runegraft"
+	Class Currency
+	SetBackgroundColor 170 158 130
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+Show
+	BaseType "Astrolabe"
+	Class Currency
+	SetBackgroundColor 0 225 125
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 100
+	MinimapIcon 2 Green Circle
+	PlayEffect Green Temp
+	DisableDropSound
 #6L Blocks - located up here due to code priority issues. 5L and 6S blocks are in the Sockets section (7)
 #corrupted catcher
 Show
@@ -6207,15 +6277,6 @@ Show
 	PlayAlertSound 11 200
 	MinimapIcon 1 Cyan Raindrop
 	PlayEffect Cyan Temp
-Show
-	BaseType "Time-light Scroll" "Fragmentation Scroll" "Deregulation Scroll" "Electroshock Scroll" "Haemocombustion Scroll" "Specularity Scroll"
-	SetBackgroundColor 250 40 0
-	SetBorderColor 250 250 250
-	SetTextColor 0 0 0
-	SetFontSize 45
-	PlayAlertSound 2 200
-	MinimapIcon 0 Orange Triangle
-	PlayEffect Orange
 Show
 	BaseType "Facetor's Lens"
 	SetBackgroundColor 0 200 240
@@ -8739,7 +8800,7 @@ Show
 
 #Maximum Tier - 100c+. White.
 Show
-	BaseType == "The Doctor" "The Fiend" "House of Mirrors" "Immortal Resolve" "The Demon" "Beauty Through Death" "The Cheater" "Unrequited Love" "Love Through Ice" "The Apothecary" "The Shieldbearer" "Choking Guilt" "The Price of Devotion" "The Insane Cat" "Brother's Gift" "The Immortal" "The Sephirot"
+	BaseType == "The Doctor" "The Fiend" "House of Mirrors" "Immortal Resolve" "The Demon" "Beauty Through Death" "Unrequited Love" "Love Through Ice" "The Apothecary" "The Shieldbearer" "Choking Guilt" "The Price of Devotion" "The Insane Cat" "Brother's Gift" "The Immortal" "The Sephirot"
 	SetBackgroundColor 250 250 250
 	SetBorderColor 0 0 0
 	SetTextColor 240 0 240
@@ -8805,7 +8866,7 @@ Show
 
 #Dogshit Tier: Hidden in all filters, waste of a click to pick up. Same highlight as trash tier. Only the very worst get added here.
 Hide
-	BaseType == "The Carrion Crow" "The Surgeon" "The King's Blade" "The Lunaris Priestess" "The Metalsmith's Gift" "Lantador's Lost Love" "The Scholar" "The Sigil" "The Lover" "The Puzzle" "The Warden" "Rain Tempter" "Rain of Chaos" "Prosperity" "Struck By Lightning" "The Inoculated" "The Opulent" "The Scarred Meadow" "Destined to Crumble" "Thirst for Knowledge" "The Witch" "The Visionary" "The Sword King's Salute" "The Harvester" "Rats" "Might is Right" "The Adventuring Spirit"
+	BaseType == "The Carrion Crow" "The Surgeon" "The King's Blade" "The Lunaris Priestess" "The Metalsmith's Gift" "Lantador's Lost Love" "The Scholar" "The Sigil" "The Lover" "The Warden" "Rain Tempter" "Rain of Chaos" "Prosperity" "Struck By Lightning" "The Inoculated" "The Opulent" "The Scarred Meadow" "Destined to Crumble" "Thirst for Knowledge" "The Witch" "The Visionary" "The Sword King's Salute" "The Harvester" "Rats" "Might is Right" "The Adventuring Spirit"
 	Class "Divination Card"
 	SetBackgroundColor 110 160 210
 	SetBorderColor 0 0 0
@@ -13088,7 +13149,7 @@ Show
 ###################################################################################
 #top and rare gems
 Show
-	BaseType "Item Quantity" "Awakened"
+	BaseType "Item Quantity" "Awakened" "Exceptional"
 	Class "Gem"
 	SetBackgroundColor 250 250 250
 	SetBorderColor 0 0 0

--- a/gpCasterShieldCharge.filter
+++ b/gpCasterShieldCharge.filter
@@ -1,4 +1,4 @@
-#Sovereign Filter by StupidFatHobbit updated 4/24/23 | Crucible League | v3.21.1 | GENERAL VERSION
+#Sovereign Filter by StupidFatHobbit updated 3/6/26 | 3.28 Update | GENERAL VERSION
 #Update Notes: Long Overdue Economy Update (Crucible League Update I)
 
 #defaultcolors:
@@ -2197,7 +2197,7 @@ Show
 #Show 
 #	Quality >= 5
 #	Class "Gem"
-#	BaseType == "Absolution" "Added Fire Damage Support" "Animate Guardian" "Animate Weapon" "Bear Trap" "Blade Blast" "Blade Flurry" "Bladefall" "Blood Rage" "Bloodlust Support" "Bloodthirst Support" "Boneshatter" "Brutality Support" "Chance to Bleed Support" "Cleave" "Corrupting Cry Support" "Corrupting Fever" "Cyclone" "Defiance Banner" "Determination" "Divine Ire" "Double Strike" "Dread Banner" "Ethereal Knives" "Explosive Trap" "Exsanguinate" "Glacial Cascade" "Herald of Agony" "Herald of Purity" "Holy Flame Totem" "Hydrosphere" "Impale Support" "Intimidating Cry" "Iron Grip Support" "Lacerate" "Lancing Steel" "Maim Support" "Melee Physical Damage Support" "Molten Shell" "Penance Brand" "Perforate" "Phase Run" "Physical to Lightning Support" "Pride" "Puncture" "Punishment" "Purifying Flame" "Reap" "Swordstorm" "Glacial Shield Swipe" "Seismic Trap" "Shattering Steel" "Shield Charge" "Shield Crush" "Shockwave Totem" "Shrapnel Ballista" "Snipe" "Spectral Shield Throw" "Split Arrow" "Splitting Steel" "Storm Burst" "Summon Carrion Golem" "Summon Reaper" "Summon Stone Golem" "Sweep" "Tornado" "Trauma Support" "Unearth" "Vaal Absolution" "Vaal Animate Weapon" "Vaal Blade Flurry" "Vaal Blade Vortex" "Vaal Cleave" "Vaal Cyclone" "Vaal Double Strike" "Vaal Molten Shell" "Vaal Reap" "Crushing Fist" "Vicious Projectiles Support" "Void Sphere" "Vulnerability" "War Banner" "Wave of Conviction" "Withering Touch Support"
+#	BaseType == "Absolution" "Added Fire Damage Support" "Animate Guardian" "Animate Weapon" "Bear Trap" "Blade Blast" "Blade Flurry" "Bladefall" "Blood Rage" "Bloodlust Support" "Bloodthirst Support" "Boneshatter" "Brutality Support" "Chance to Bleed Support" "Cleave" "Corrupting Cry Support" "Corrupting Fever" "Cyclone" "Defiance Banner" "Determination" "Divine Ire" "Double Strike" "Dread Banner" "Ethereal Knives" "Explosive Trap" "Exsanguinate" "Glacial Cascade" "Herald of Agony" "Herald of Purity" "Holy Flame Totem" "Hydrosphere" "Impale Support" "Intimidating Cry" "Iron Grip Support" "Lacerate" "Lancing Steel" "Maim Support" "Melee Physical Damage Support" "Molten Shell" "Penance Brand" "Perforate" "Phase Run" "Physical to Lightning Support" "Pride" "Puncture" "Punishment" "Purifying Flame" "Reap" "Swordstorm" "Glacial Shield Swipe" "Seismic Trap" "Shattering Steel" "Shield Charge" "Shield Crush" "Shockwave Totem" "Shrapnel Ballista" "Snipe" "Spectral Shield Throw" "Split Arrow" "Splitting Steel" "Storm Burst" "Summon Carrion Golem" "Summon Reaper" "Summon Stone Golem" "Holy Sweep" "Tornado" "Trauma Support" "Unearth" "Vaal Absolution" "Vaal Animate Weapon" "Vaal Blade Flurry" "Vaal Blade Vortex" "Vaal Cleave" "Vaal Cyclone" "Vaal Double Strike" "Vaal Molten Shell" "Vaal Reap" "Crushing Fist" "Vicious Projectiles Support" "Void Sphere" "Vulnerability" "War Banner" "Wave of Conviction" "Withering Touch Support"
 #	SetBackgroundColor 180 0 0
 #	SetBorderColor 0 0 0
 #	SetTextColor 0 0 0
@@ -3020,7 +3020,7 @@ Show
 #Show 
 #	Quality >= 5
 #	Class "Gem"
-#	BaseType == "Absolution" "Added Fire Damage Support" "Animate Guardian" "Animate Weapon" "Bear Trap" "Blade Blast" "Blade Flurry" "Bladefall" "Blood Rage" "Bloodlust Support" "Bloodthirst Support" "Boneshatter" "Brutality Support" "Chance to Bleed Support" "Cleave" "Corrupting Cry Support" "Corrupting Fever" "Cyclone" "Defiance Banner" "Determination" "Divine Ire" "Double Strike" "Dread Banner" "Ethereal Knives" "Explosive Trap" "Exsanguinate" "Glacial Cascade" "Herald of Agony" "Herald of Purity" "Holy Flame Totem" "Hydrosphere" "Impale Support" "Intimidating Cry" "Iron Grip Support" "Lacerate" "Lancing Steel" "Maim Support" "Melee Physical Damage Support" "Molten Shell" "Penance Brand" "Perforate" "Phase Run" "Physical to Lightning Support" "Pride" "Puncture" "Punishment" "Purifying Flame" "Reap" "Swordstorm" "Glacial Shield Swipe" "Seismic Trap" "Shattering Steel" "Shield Charge" "Shield Crush" "Shockwave Totem" "Shrapnel Ballista" "Snipe" "Spectral Shield Throw" "Split Arrow" "Splitting Steel" "Storm Burst" "Summon Carrion Golem" "Summon Reaper" "Summon Stone Golem" "Sweep" "Tornado" "Trauma Support" "Unearth" "Vaal Absolution" "Vaal Animate Weapon" "Vaal Blade Flurry" "Vaal Blade Vortex" "Vaal Cleave" "Vaal Cyclone" "Vaal Double Strike" "Vaal Molten Shell" "Vaal Reap" "Crushing Fist" "Vicious Projectiles Support" "Void Sphere" "Vulnerability" "War Banner" "Wave of Conviction" "Withering Touch Support"
+#	BaseType == "Absolution" "Added Fire Damage Support" "Animate Guardian" "Animate Weapon" "Bear Trap" "Blade Blast" "Blade Flurry" "Bladefall" "Blood Rage" "Bloodlust Support" "Bloodthirst Support" "Boneshatter" "Brutality Support" "Chance to Bleed Support" "Cleave" "Corrupting Cry Support" "Corrupting Fever" "Cyclone" "Defiance Banner" "Determination" "Divine Ire" "Double Strike" "Dread Banner" "Ethereal Knives" "Explosive Trap" "Exsanguinate" "Glacial Cascade" "Herald of Agony" "Herald of Purity" "Holy Flame Totem" "Hydrosphere" "Impale Support" "Intimidating Cry" "Iron Grip Support" "Lacerate" "Lancing Steel" "Maim Support" "Melee Physical Damage Support" "Molten Shell" "Penance Brand" "Perforate" "Phase Run" "Physical to Lightning Support" "Pride" "Puncture" "Punishment" "Purifying Flame" "Reap" "Swordstorm" "Glacial Shield Swipe" "Seismic Trap" "Shattering Steel" "Shield Charge" "Shield Crush" "Shockwave Totem" "Shrapnel Ballista" "Snipe" "Spectral Shield Throw" "Split Arrow" "Splitting Steel" "Storm Burst" "Summon Carrion Golem" "Summon Reaper" "Summon Stone Golem" "Holy Sweep" "Tornado" "Trauma Support" "Unearth" "Vaal Absolution" "Vaal Animate Weapon" "Vaal Blade Flurry" "Vaal Blade Vortex" "Vaal Cleave" "Vaal Cyclone" "Vaal Double Strike" "Vaal Molten Shell" "Vaal Reap" "Crushing Fist" "Vicious Projectiles Support" "Void Sphere" "Vulnerability" "War Banner" "Wave of Conviction" "Withering Touch Support"
 #	SetBackgroundColor 180 0 0
 #	SetBorderColor 0 0 0
 #	SetTextColor 0 0 0
@@ -4224,6 +4224,16 @@ Show
 	DisableDropSound
 
 Show
+	BaseType "Volatile Vaal Orb" "Flesh of Xesht"
+	SetBackgroundColor 240 0 200
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	PlayAlertSound 10 250
+	SetFontSize 45
+	MinimapIcon 1 Pink Circle
+	PlayEffect Pink
+	DisableDropSound
+Show
 	BaseType "Orb of Binding" "Veiled" "Enkindling Orb" "Instilling Orb" "Oil Extractor"
 	Class "Currency"
 	SetBackgroundColor 0 225 125
@@ -4300,6 +4310,68 @@ Show
 	SetFontSize 38
 	AreaLevel <= 78
 	
+
+#3.28 New Currencies
+Show
+	BaseType "Coin of Knowledge" "Coin of Power" "Coin of Skill" "Coin of Restoration" "Coin of Desecration"
+	Class Currency
+	SetBackgroundColor 0 225 125
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 100
+	MinimapIcon 2 Green Circle
+	PlayEffect Green Temp
+	DisableDropSound
+Show
+	BaseType "Refracting Fog" "Essence of Desolation" "Crystallised Rancour"
+	Class Currency
+	SetBackgroundColor 0 185 185
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 125
+	MinimapIcon 2 Cyan Circle
+	DisableDropSound
+Show
+	BaseType "Sinistral Catalyst" "Dextral Catalyst"
+	Class Currency
+	SetBackgroundColor 0 225 125
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 100
+	MinimapIcon 2 Green Circle
+	PlayEffect Green Temp
+	DisableDropSound
+Show
+	BaseType "Memory of Trauma" "Memory of Reverence" "Memory of Loneliness"
+	Class Currency
+	SetBackgroundColor 0 185 185
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 125
+	MinimapIcon 2 Cyan Circle
+	DisableDropSound
+Show
+	BaseType "Runegraft"
+	Class Currency
+	SetBackgroundColor 170 158 130
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+Show
+	BaseType "Astrolabe"
+	Class Currency
+	SetBackgroundColor 0 225 125
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 100
+	MinimapIcon 2 Green Circle
+	PlayEffect Green Temp
+	DisableDropSound
 #6L Blocks - located up here due to code priority issues. 5L and 6S blocks are in the Sockets section (7)
 #corrupted catcher
 Show
@@ -5515,15 +5587,6 @@ Show
 	PlayAlertSound 11 200
 	MinimapIcon 1 Cyan Raindrop
 	PlayEffect Cyan Temp
-Show
-	BaseType "Time-light Scroll" "Fragmentation Scroll" "Deregulation Scroll" "Electroshock Scroll" "Haemocombustion Scroll" "Specularity Scroll"
-	SetBackgroundColor 250 40 0
-	SetBorderColor 250 250 250
-	SetTextColor 0 0 0
-	SetFontSize 45
-	PlayAlertSound 2 200
-	MinimapIcon 0 Orange Triangle
-	PlayEffect Orange
 Show
 	BaseType "Facetor's Lens"
 	SetBackgroundColor 0 200 240
@@ -8046,7 +8109,7 @@ Show
 
 #Maximum Tier - 100c+. White.
 Show
-	BaseType == "The Doctor" "The Fiend" "House of Mirrors" "Immortal Resolve" "The Demon" "Beauty Through Death" "The Cheater" "Unrequited Love" "Love Through Ice" "The Apothecary" "The Shieldbearer" "Choking Guilt" "The Price of Devotion" "The Insane Cat" "Brother's Gift" "The Immortal" "The Sephirot"
+	BaseType == "The Doctor" "The Fiend" "House of Mirrors" "Immortal Resolve" "The Demon" "Beauty Through Death" "Unrequited Love" "Love Through Ice" "The Apothecary" "The Shieldbearer" "Choking Guilt" "The Price of Devotion" "The Insane Cat" "Brother's Gift" "The Immortal" "The Sephirot"
 	SetBackgroundColor 250 250 250
 	SetBorderColor 0 0 0
 	SetTextColor 240 0 240
@@ -8112,7 +8175,7 @@ Show
 
 #Dogshit Tier: Hidden in all filters, waste of a click to pick up. Same highlight as trash tier. Only the very worst get added here.
 Hide
-	BaseType == "The Carrion Crow" "The Surgeon" "The King's Blade" "The Lunaris Priestess" "The Metalsmith's Gift" "Lantador's Lost Love" "The Scholar" "The Sigil" "The Lover" "The Puzzle" "The Warden" "Rain Tempter" "Rain of Chaos" "Prosperity" "Struck By Lightning" "The Inoculated" "The Opulent" "The Scarred Meadow" "Destined to Crumble" "Thirst for Knowledge" "The Witch" "The Visionary" "The Sword King's Salute" "The Harvester" "Rats" "Might is Right" "The Adventuring Spirit"
+	BaseType == "The Carrion Crow" "The Surgeon" "The King's Blade" "The Lunaris Priestess" "The Metalsmith's Gift" "Lantador's Lost Love" "The Scholar" "The Sigil" "The Lover" "The Warden" "Rain Tempter" "Rain of Chaos" "Prosperity" "Struck By Lightning" "The Inoculated" "The Opulent" "The Scarred Meadow" "Destined to Crumble" "Thirst for Knowledge" "The Witch" "The Visionary" "The Sword King's Salute" "The Harvester" "Rats" "Might is Right" "The Adventuring Spirit"
 	Class "Divination Card"
 	SetBackgroundColor 110 160 210
 	SetBorderColor 0 0 0
@@ -12393,7 +12456,7 @@ Show
 ###################################################################################
 #top and rare gems
 Show
-	BaseType "Item Quantity" "Awakened"
+	BaseType "Item Quantity" "Awakened" "Exceptional"
 	Class "Gem"
 	SetBackgroundColor 250 250 250
 	SetBorderColor 0 0 0

--- a/gpCasterWhirling.filter
+++ b/gpCasterWhirling.filter
@@ -1,4 +1,4 @@
-#Sovereign Filter by StupidFatHobbit updated 4/24/23 | Crucible League | v3.21.1 | GENERAL VERSION
+#Sovereign Filter by StupidFatHobbit updated 3/6/26 | 3.28 Update | GENERAL VERSION
 #Update Notes: Long Overdue Economy Update (Crucible League Update I)
 
 #defaultcolors:
@@ -2959,7 +2959,7 @@ Show
 #Show 
 #	Quality >= 5
 #	Class "Gem"
-#	BaseType == "Absolution" "Added Fire Damage Support" "Animate Guardian" "Animate Weapon" "Bear Trap" "Blade Blast" "Blade Flurry" "Bladefall" "Blood Rage" "Bloodlust Support" "Bloodthirst Support" "Boneshatter" "Brutality Support" "Chance to Bleed Support" "Cleave" "Corrupting Cry Support" "Corrupting Fever" "Cyclone" "Defiance Banner" "Determination" "Divine Ire" "Double Strike" "Dread Banner" "Ethereal Knives" "Explosive Trap" "Exsanguinate" "Glacial Cascade" "Herald of Agony" "Herald of Purity" "Holy Flame Totem" "Hydrosphere" "Impale Support" "Intimidating Cry" "Iron Grip Support" "Lacerate" "Lancing Steel" "Maim Support" "Melee Physical Damage Support" "Molten Shell" "Penance Brand" "Perforate" "Phase Run" "Physical to Lightning Support" "Pride" "Puncture" "Punishment" "Purifying Flame" "Reap" "Swordstorm" "Glacial Shield Swipe" "Seismic Trap" "Shattering Steel" "Shield Charge" "Shield Crush" "Shockwave Totem" "Shrapnel Ballista" "Snipe" "Spectral Shield Throw" "Split Arrow" "Splitting Steel" "Storm Burst" "Summon Carrion Golem" "Summon Reaper" "Summon Stone Golem" "Sweep" "Tornado" "Trauma Support" "Unearth" "Vaal Absolution" "Vaal Animate Weapon" "Vaal Blade Flurry" "Vaal Blade Vortex" "Vaal Cleave" "Vaal Cyclone" "Vaal Double Strike" "Vaal Molten Shell" "Vaal Reap" "Crushing Fist" "Vicious Projectiles Support" "Void Sphere" "Vulnerability" "War Banner" "Wave of Conviction" "Withering Touch Support"
+#	BaseType == "Absolution" "Added Fire Damage Support" "Animate Guardian" "Animate Weapon" "Bear Trap" "Blade Blast" "Blade Flurry" "Bladefall" "Blood Rage" "Bloodlust Support" "Bloodthirst Support" "Boneshatter" "Brutality Support" "Chance to Bleed Support" "Cleave" "Corrupting Cry Support" "Corrupting Fever" "Cyclone" "Defiance Banner" "Determination" "Divine Ire" "Double Strike" "Dread Banner" "Ethereal Knives" "Explosive Trap" "Exsanguinate" "Glacial Cascade" "Herald of Agony" "Herald of Purity" "Holy Flame Totem" "Hydrosphere" "Impale Support" "Intimidating Cry" "Iron Grip Support" "Lacerate" "Lancing Steel" "Maim Support" "Melee Physical Damage Support" "Molten Shell" "Penance Brand" "Perforate" "Phase Run" "Physical to Lightning Support" "Pride" "Puncture" "Punishment" "Purifying Flame" "Reap" "Swordstorm" "Glacial Shield Swipe" "Seismic Trap" "Shattering Steel" "Shield Charge" "Shield Crush" "Shockwave Totem" "Shrapnel Ballista" "Snipe" "Spectral Shield Throw" "Split Arrow" "Splitting Steel" "Storm Burst" "Summon Carrion Golem" "Summon Reaper" "Summon Stone Golem" "Holy Sweep" "Tornado" "Trauma Support" "Unearth" "Vaal Absolution" "Vaal Animate Weapon" "Vaal Blade Flurry" "Vaal Blade Vortex" "Vaal Cleave" "Vaal Cyclone" "Vaal Double Strike" "Vaal Molten Shell" "Vaal Reap" "Crushing Fist" "Vicious Projectiles Support" "Void Sphere" "Vulnerability" "War Banner" "Wave of Conviction" "Withering Touch Support"
 #	SetBackgroundColor 180 0 0
 #	SetBorderColor 0 0 0
 #	SetTextColor 0 0 0
@@ -3782,7 +3782,7 @@ Show
 #Show 
 #	Quality >= 5
 #	Class "Gem"
-#	BaseType == "Absolution" "Added Fire Damage Support" "Animate Guardian" "Animate Weapon" "Bear Trap" "Blade Blast" "Blade Flurry" "Bladefall" "Blood Rage" "Bloodlust Support" "Bloodthirst Support" "Boneshatter" "Brutality Support" "Chance to Bleed Support" "Cleave" "Corrupting Cry Support" "Corrupting Fever" "Cyclone" "Defiance Banner" "Determination" "Divine Ire" "Double Strike" "Dread Banner" "Ethereal Knives" "Explosive Trap" "Exsanguinate" "Glacial Cascade" "Herald of Agony" "Herald of Purity" "Holy Flame Totem" "Hydrosphere" "Impale Support" "Intimidating Cry" "Iron Grip Support" "Lacerate" "Lancing Steel" "Maim Support" "Melee Physical Damage Support" "Molten Shell" "Penance Brand" "Perforate" "Phase Run" "Physical to Lightning Support" "Pride" "Puncture" "Punishment" "Purifying Flame" "Reap" "Swordstorm" "Glacial Shield Swipe" "Seismic Trap" "Shattering Steel" "Shield Charge" "Shield Crush" "Shockwave Totem" "Shrapnel Ballista" "Snipe" "Spectral Shield Throw" "Split Arrow" "Splitting Steel" "Storm Burst" "Summon Carrion Golem" "Summon Reaper" "Summon Stone Golem" "Sweep" "Tornado" "Trauma Support" "Unearth" "Vaal Absolution" "Vaal Animate Weapon" "Vaal Blade Flurry" "Vaal Blade Vortex" "Vaal Cleave" "Vaal Cyclone" "Vaal Double Strike" "Vaal Molten Shell" "Vaal Reap" "Crushing Fist" "Vicious Projectiles Support" "Void Sphere" "Vulnerability" "War Banner" "Wave of Conviction" "Withering Touch Support"
+#	BaseType == "Absolution" "Added Fire Damage Support" "Animate Guardian" "Animate Weapon" "Bear Trap" "Blade Blast" "Blade Flurry" "Bladefall" "Blood Rage" "Bloodlust Support" "Bloodthirst Support" "Boneshatter" "Brutality Support" "Chance to Bleed Support" "Cleave" "Corrupting Cry Support" "Corrupting Fever" "Cyclone" "Defiance Banner" "Determination" "Divine Ire" "Double Strike" "Dread Banner" "Ethereal Knives" "Explosive Trap" "Exsanguinate" "Glacial Cascade" "Herald of Agony" "Herald of Purity" "Holy Flame Totem" "Hydrosphere" "Impale Support" "Intimidating Cry" "Iron Grip Support" "Lacerate" "Lancing Steel" "Maim Support" "Melee Physical Damage Support" "Molten Shell" "Penance Brand" "Perforate" "Phase Run" "Physical to Lightning Support" "Pride" "Puncture" "Punishment" "Purifying Flame" "Reap" "Swordstorm" "Glacial Shield Swipe" "Seismic Trap" "Shattering Steel" "Shield Charge" "Shield Crush" "Shockwave Totem" "Shrapnel Ballista" "Snipe" "Spectral Shield Throw" "Split Arrow" "Splitting Steel" "Storm Burst" "Summon Carrion Golem" "Summon Reaper" "Summon Stone Golem" "Holy Sweep" "Tornado" "Trauma Support" "Unearth" "Vaal Absolution" "Vaal Animate Weapon" "Vaal Blade Flurry" "Vaal Blade Vortex" "Vaal Cleave" "Vaal Cyclone" "Vaal Double Strike" "Vaal Molten Shell" "Vaal Reap" "Crushing Fist" "Vicious Projectiles Support" "Void Sphere" "Vulnerability" "War Banner" "Wave of Conviction" "Withering Touch Support"
 #	SetBackgroundColor 180 0 0
 #	SetBorderColor 0 0 0
 #	SetTextColor 0 0 0
@@ -4987,6 +4987,16 @@ Show
 	DisableDropSound
 
 Show
+	BaseType "Volatile Vaal Orb" "Flesh of Xesht"
+	SetBackgroundColor 240 0 200
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	PlayAlertSound 10 250
+	SetFontSize 45
+	MinimapIcon 1 Pink Circle
+	PlayEffect Pink
+	DisableDropSound
+Show
 	BaseType "Orb of Binding" "Veiled" "Enkindling Orb" "Instilling Orb"
 	Class "Currency"
 	SetBackgroundColor 0 225 125
@@ -5063,6 +5073,68 @@ Show
 	SetFontSize 38
 	AreaLevel <= 78
 	
+
+#3.28 New Currencies
+Show
+	BaseType "Coin of Knowledge" "Coin of Power" "Coin of Skill" "Coin of Restoration" "Coin of Desecration"
+	Class Currency
+	SetBackgroundColor 0 225 125
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 100
+	MinimapIcon 2 Green Circle
+	PlayEffect Green Temp
+	DisableDropSound
+Show
+	BaseType "Refracting Fog" "Essence of Desolation" "Crystallised Rancour"
+	Class Currency
+	SetBackgroundColor 0 185 185
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 125
+	MinimapIcon 2 Cyan Circle
+	DisableDropSound
+Show
+	BaseType "Sinistral Catalyst" "Dextral Catalyst"
+	Class Currency
+	SetBackgroundColor 0 225 125
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 100
+	MinimapIcon 2 Green Circle
+	PlayEffect Green Temp
+	DisableDropSound
+Show
+	BaseType "Memory of Trauma" "Memory of Reverence" "Memory of Loneliness"
+	Class Currency
+	SetBackgroundColor 0 185 185
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 125
+	MinimapIcon 2 Cyan Circle
+	DisableDropSound
+Show
+	BaseType "Runegraft"
+	Class Currency
+	SetBackgroundColor 170 158 130
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+Show
+	BaseType "Astrolabe"
+	Class Currency
+	SetBackgroundColor 0 225 125
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 100
+	MinimapIcon 2 Green Circle
+	PlayEffect Green Temp
+	DisableDropSound
 #6L Blocks - located up here due to code priority issues. 5L and 6S blocks are in the Sockets section (7)
 #corrupted catcher
 Show
@@ -6277,15 +6349,6 @@ Show
 	PlayAlertSound 11 200
 	MinimapIcon 1 Cyan Raindrop
 	PlayEffect Cyan Temp
-Show
-	BaseType "Time-light Scroll" "Fragmentation Scroll" "Deregulation Scroll" "Electroshock Scroll" "Haemocombustion Scroll" "Specularity Scroll"
-	SetBackgroundColor 250 40 0
-	SetBorderColor 250 250 250
-	SetTextColor 0 0 0
-	SetFontSize 45
-	PlayAlertSound 2 200
-	MinimapIcon 0 Orange Triangle
-	PlayEffect Orange
 Show
 	BaseType "Facetor's Lens"
 	SetBackgroundColor 0 200 240
@@ -8821,7 +8884,7 @@ Show
 
 #Maximum Tier - 100c+. White.
 Show
-	BaseType == "The Doctor" "The Fiend" "House of Mirrors" "Immortal Resolve" "The Demon" "Beauty Through Death" "The Cheater" "Unrequited Love" "Love Through Ice" "The Apothecary" "The Shieldbearer" "Choking Guilt" "The Price of Devotion" "The Insane Cat" "Brother's Gift" "The Immortal" "The Sephirot"
+	BaseType == "The Doctor" "The Fiend" "House of Mirrors" "Immortal Resolve" "The Demon" "Beauty Through Death" "Unrequited Love" "Love Through Ice" "The Apothecary" "The Shieldbearer" "Choking Guilt" "The Price of Devotion" "The Insane Cat" "Brother's Gift" "The Immortal" "The Sephirot"
 	SetBackgroundColor 250 250 250
 	SetBorderColor 0 0 0
 	SetTextColor 240 0 240
@@ -8887,7 +8950,7 @@ Show
 
 #Dogshit Tier: Hidden in all filters, waste of a click to pick up. Same highlight as trash tier. Only the very worst get added here.
 Hide
-	BaseType == "The Carrion Crow" "The Surgeon" "The King's Blade" "The Lunaris Priestess" "The Metalsmith's Gift" "Lantador's Lost Love" "The Scholar" "The Sigil" "The Lover" "The Puzzle" "The Warden" "Rain Tempter" "Rain of Chaos" "Prosperity" "Struck By Lightning" "The Inoculated" "The Opulent" "The Scarred Meadow" "Destined to Crumble" "Thirst for Knowledge" "The Witch" "The Visionary" "The Sword King's Salute" "The Harvester" "Rats" "Might is Right" "The Adventuring Spirit"
+	BaseType == "The Carrion Crow" "The Surgeon" "The King's Blade" "The Lunaris Priestess" "The Metalsmith's Gift" "Lantador's Lost Love" "The Scholar" "The Sigil" "The Lover" "The Warden" "Rain Tempter" "Rain of Chaos" "Prosperity" "Struck By Lightning" "The Inoculated" "The Opulent" "The Scarred Meadow" "Destined to Crumble" "Thirst for Knowledge" "The Witch" "The Visionary" "The Sword King's Salute" "The Harvester" "Rats" "Might is Right" "The Adventuring Spirit"
 	Class "Divination Card"
 	SetBackgroundColor 110 160 210
 	SetBorderColor 0 0 0
@@ -13168,7 +13231,7 @@ Show
 ###################################################################################
 #top and rare gems
 Show
-	BaseType "Item Quantity" "Awakened"
+	BaseType "Item Quantity" "Awakened" "Exceptional"
 	Class "Gem"
 	SetBackgroundColor 250 250 250
 	SetBorderColor 0 0 0

--- a/gpEPconc.filter
+++ b/gpEPconc.filter
@@ -1,4 +1,4 @@
-#Sovereign Filter by StupidFatHobbit updated 4/24/23 | Crucible League | v3.21.1 | GENERAL VERSION
+#Sovereign Filter by StupidFatHobbit updated 3/6/26 | 3.28 Update | GENERAL VERSION
 #Update Notes: Long Overdue Economy Update (Crucible League Update I)
 
 #defaultcolors:
@@ -3120,6 +3120,16 @@ Show
 	DisableDropSound
 
 Show
+	BaseType "Volatile Vaal Orb" "Flesh of Xesht"
+	SetBackgroundColor 240 0 200
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	PlayAlertSound 10 250
+	SetFontSize 45
+	MinimapIcon 1 Pink Circle
+	PlayEffect Pink
+	DisableDropSound
+Show
 	BaseType "Orb of Binding" "Veiled" "Enkindling Orb" "Instilling Orb" "Oil Extractor"
 	Class Currency
 	SetBackgroundColor 0 225 125
@@ -3196,6 +3206,68 @@ Show
 	SetFontSize 38
 	AreaLevel <= 78
 	
+
+#3.28 New Currencies
+Show
+	BaseType "Coin of Knowledge" "Coin of Power" "Coin of Skill" "Coin of Restoration" "Coin of Desecration"
+	Class Currency
+	SetBackgroundColor 0 225 125
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 100
+	MinimapIcon 2 Green Circle
+	PlayEffect Green Temp
+	DisableDropSound
+Show
+	BaseType "Refracting Fog" "Essence of Desolation" "Crystallised Rancour"
+	Class Currency
+	SetBackgroundColor 0 185 185
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 125
+	MinimapIcon 2 Cyan Circle
+	DisableDropSound
+Show
+	BaseType "Sinistral Catalyst" "Dextral Catalyst"
+	Class Currency
+	SetBackgroundColor 0 225 125
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 100
+	MinimapIcon 2 Green Circle
+	PlayEffect Green Temp
+	DisableDropSound
+Show
+	BaseType "Memory of Trauma" "Memory of Reverence" "Memory of Loneliness"
+	Class Currency
+	SetBackgroundColor 0 185 185
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 125
+	MinimapIcon 2 Cyan Circle
+	DisableDropSound
+Show
+	BaseType "Runegraft"
+	Class Currency
+	SetBackgroundColor 170 158 130
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+Show
+	BaseType "Astrolabe"
+	Class Currency
+	SetBackgroundColor 0 225 125
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 100
+	MinimapIcon 2 Green Circle
+	PlayEffect Green Temp
+	DisableDropSound
 #6L Blocks - located up here due to code priority issues. 5L and 6S blocks are in the Sockets section (7)
 #corrupted catcher
 Show
@@ -4410,15 +4482,6 @@ Show
 	PlayAlertSound 11 200
 	MinimapIcon 1 Cyan Raindrop
 	PlayEffect Cyan Temp
-Show
-	BaseType "Time-light Scroll" "Fragmentation Scroll" "Deregulation Scroll" "Electroshock Scroll" "Haemocombustion Scroll" "Specularity Scroll"
-	SetBackgroundColor 250 40 0
-	SetBorderColor 250 250 250
-	SetTextColor 0 0 0
-	SetFontSize 45
-	PlayAlertSound 2 200
-	MinimapIcon 0 Orange Triangle
-	PlayEffect Orange
 Show
 	BaseType "Facetor's Lens"
 	SetBackgroundColor 0 200 240
@@ -6957,7 +7020,7 @@ Show
 
 #Maximum Tier - 100c+. White.
 Show
-	BaseType == "The Doctor" "The Fiend" "House of Mirrors" "Immortal Resolve" "The Demon" "Beauty Through Death" "The Cheater" "Unrequited Love" "Love Through Ice" "The Apothecary" "The Shieldbearer" "Choking Guilt" "The Price of Devotion" "The Insane Cat" "Brother's Gift" "The Immortal" "The Sephirot"
+	BaseType == "The Doctor" "The Fiend" "House of Mirrors" "Immortal Resolve" "The Demon" "Beauty Through Death" "Unrequited Love" "Love Through Ice" "The Apothecary" "The Shieldbearer" "Choking Guilt" "The Price of Devotion" "The Insane Cat" "Brother's Gift" "The Immortal" "The Sephirot"
 	SetBackgroundColor 250 250 250
 	SetBorderColor 0 0 0
 	SetTextColor 240 0 240
@@ -7023,7 +7086,7 @@ Show
 
 #Dogshit Tier: Hidden in all filters, waste of a click to pick up. Same highlight as trash tier. Only the very worst get added here.
 Hide
-	BaseType == "The Carrion Crow" "The Surgeon" "The King's Blade" "The Lunaris Priestess" "The Metalsmith's Gift" "Lantador's Lost Love" "The Scholar" "The Sigil" "The Lover" "The Puzzle" "The Warden" "Rain Tempter" "Rain of Chaos" "Prosperity" "Struck By Lightning" "The Inoculated" "The Opulent" "The Scarred Meadow" "Destined to Crumble" "Thirst for Knowledge" "The Witch" "The Visionary" "The Sword King's Salute" "The Harvester" "Rats" "Might is Right" "The Adventuring Spirit"
+	BaseType == "The Carrion Crow" "The Surgeon" "The King's Blade" "The Lunaris Priestess" "The Metalsmith's Gift" "Lantador's Lost Love" "The Scholar" "The Sigil" "The Lover" "The Warden" "Rain Tempter" "Rain of Chaos" "Prosperity" "Struck By Lightning" "The Inoculated" "The Opulent" "The Scarred Meadow" "Destined to Crumble" "Thirst for Knowledge" "The Witch" "The Visionary" "The Sword King's Salute" "The Harvester" "Rats" "Might is Right" "The Adventuring Spirit"
 	Class "Divination Card"
 	SetBackgroundColor 110 160 210
 	SetBorderColor 0 0 0
@@ -11305,7 +11368,7 @@ Show
 ###################################################################################
 #top and rare gems
 Show
-	BaseType "Item Quantity" "Awakened"
+	BaseType "Item Quantity" "Awakened" "Exceptional"
 	Class "Gem"
 	SetBackgroundColor 250 250 250
 	SetBorderColor 0 0 0

--- a/gpWander.filter
+++ b/gpWander.filter
@@ -1,4 +1,4 @@
-#Sovereign Filter by StupidFatHobbit updated 4/24/23 | Crucible League | v3.21.1 | GENERAL VERSION
+#Sovereign Filter by StupidFatHobbit updated 3/6/26 | 3.28 Update | GENERAL VERSION
 #Update Notes: Long Overdue Economy Update (Crucible League Update I)
 
 #defaultcolors:
@@ -2240,7 +2240,7 @@ Show
 #Show 
 #	Quality >= 5
 #	Class "Gem"
-#	BaseType == "Absolution" "Added Fire Damage Support" "Animate Guardian" "Animate Weapon" "Bear Trap" "Blade Blast" "Blade Flurry" "Bladefall" "Blood Rage" "Bloodlust Support" "Bloodthirst Support" "Boneshatter" "Brutality Support" "Chance to Bleed Support" "Cleave" "Corrupting Cry Support" "Corrupting Fever" "Cyclone" "Defiance Banner" "Determination" "Divine Ire" "Double Strike" "Dread Banner" "Ethereal Knives" "Explosive Trap" "Exsanguinate" "Glacial Cascade" "Herald of Agony" "Herald of Purity" "Holy Flame Totem" "Hydrosphere" "Impale Support" "Intimidating Cry" "Iron Grip Support" "Lacerate" "Lancing Steel" "Maim Support" "Melee Physical Damage Support" "Molten Shell" "Penance Brand" "Perforate" "Phase Run" "Physical to Lightning Support" "Pride" "Puncture" "Punishment" "Purifying Flame" "Reap" "Swordstorm" "Glacial Shield Swipe" "Seismic Trap" "Shattering Steel" "Shield Charge" "Shield Crush" "Shockwave Totem" "Shrapnel Ballista" "Snipe" "Spectral Shield Throw" "Split Arrow" "Splitting Steel" "Storm Burst" "Summon Carrion Golem" "Summon Reaper" "Summon Stone Golem" "Sweep" "Tornado" "Trauma Support" "Unearth" "Vaal Absolution" "Vaal Animate Weapon" "Vaal Blade Flurry" "Vaal Blade Vortex" "Vaal Cleave" "Vaal Cyclone" "Vaal Double Strike" "Vaal Molten Shell" "Vaal Reap" "Crushing Fist" "Vicious Projectiles Support" "Void Sphere" "Vulnerability" "War Banner" "Wave of Conviction" "Withering Touch Support"
+#	BaseType == "Absolution" "Added Fire Damage Support" "Animate Guardian" "Animate Weapon" "Bear Trap" "Blade Blast" "Blade Flurry" "Bladefall" "Blood Rage" "Bloodlust Support" "Bloodthirst Support" "Boneshatter" "Brutality Support" "Chance to Bleed Support" "Cleave" "Corrupting Cry Support" "Corrupting Fever" "Cyclone" "Defiance Banner" "Determination" "Divine Ire" "Double Strike" "Dread Banner" "Ethereal Knives" "Explosive Trap" "Exsanguinate" "Glacial Cascade" "Herald of Agony" "Herald of Purity" "Holy Flame Totem" "Hydrosphere" "Impale Support" "Intimidating Cry" "Iron Grip Support" "Lacerate" "Lancing Steel" "Maim Support" "Melee Physical Damage Support" "Molten Shell" "Penance Brand" "Perforate" "Phase Run" "Physical to Lightning Support" "Pride" "Puncture" "Punishment" "Purifying Flame" "Reap" "Swordstorm" "Glacial Shield Swipe" "Seismic Trap" "Shattering Steel" "Shield Charge" "Shield Crush" "Shockwave Totem" "Shrapnel Ballista" "Snipe" "Spectral Shield Throw" "Split Arrow" "Splitting Steel" "Storm Burst" "Summon Carrion Golem" "Summon Reaper" "Summon Stone Golem" "Holy Sweep" "Tornado" "Trauma Support" "Unearth" "Vaal Absolution" "Vaal Animate Weapon" "Vaal Blade Flurry" "Vaal Blade Vortex" "Vaal Cleave" "Vaal Cyclone" "Vaal Double Strike" "Vaal Molten Shell" "Vaal Reap" "Crushing Fist" "Vicious Projectiles Support" "Void Sphere" "Vulnerability" "War Banner" "Wave of Conviction" "Withering Touch Support"
 #	SetBackgroundColor 180 0 0
 #	SetBorderColor 0 0 0
 #	SetTextColor 0 0 0
@@ -3063,7 +3063,7 @@ Show
 #Show 
 #	Quality >= 5
 #	Class "Gem"
-#	BaseType == "Absolution" "Added Fire Damage Support" "Animate Guardian" "Animate Weapon" "Bear Trap" "Blade Blast" "Blade Flurry" "Bladefall" "Blood Rage" "Bloodlust Support" "Bloodthirst Support" "Boneshatter" "Brutality Support" "Chance to Bleed Support" "Cleave" "Corrupting Cry Support" "Corrupting Fever" "Cyclone" "Defiance Banner" "Determination" "Divine Ire" "Double Strike" "Dread Banner" "Ethereal Knives" "Explosive Trap" "Exsanguinate" "Glacial Cascade" "Herald of Agony" "Herald of Purity" "Holy Flame Totem" "Hydrosphere" "Impale Support" "Intimidating Cry" "Iron Grip Support" "Lacerate" "Lancing Steel" "Maim Support" "Melee Physical Damage Support" "Molten Shell" "Penance Brand" "Perforate" "Phase Run" "Physical to Lightning Support" "Pride" "Puncture" "Punishment" "Purifying Flame" "Reap" "Swordstorm" "Glacial Shield Swipe" "Seismic Trap" "Shattering Steel" "Shield Charge" "Shield Crush" "Shockwave Totem" "Shrapnel Ballista" "Snipe" "Spectral Shield Throw" "Split Arrow" "Splitting Steel" "Storm Burst" "Summon Carrion Golem" "Summon Reaper" "Summon Stone Golem" "Sweep" "Tornado" "Trauma Support" "Unearth" "Vaal Absolution" "Vaal Animate Weapon" "Vaal Blade Flurry" "Vaal Blade Vortex" "Vaal Cleave" "Vaal Cyclone" "Vaal Double Strike" "Vaal Molten Shell" "Vaal Reap" "Crushing Fist" "Vicious Projectiles Support" "Void Sphere" "Vulnerability" "War Banner" "Wave of Conviction" "Withering Touch Support"
+#	BaseType == "Absolution" "Added Fire Damage Support" "Animate Guardian" "Animate Weapon" "Bear Trap" "Blade Blast" "Blade Flurry" "Bladefall" "Blood Rage" "Bloodlust Support" "Bloodthirst Support" "Boneshatter" "Brutality Support" "Chance to Bleed Support" "Cleave" "Corrupting Cry Support" "Corrupting Fever" "Cyclone" "Defiance Banner" "Determination" "Divine Ire" "Double Strike" "Dread Banner" "Ethereal Knives" "Explosive Trap" "Exsanguinate" "Glacial Cascade" "Herald of Agony" "Herald of Purity" "Holy Flame Totem" "Hydrosphere" "Impale Support" "Intimidating Cry" "Iron Grip Support" "Lacerate" "Lancing Steel" "Maim Support" "Melee Physical Damage Support" "Molten Shell" "Penance Brand" "Perforate" "Phase Run" "Physical to Lightning Support" "Pride" "Puncture" "Punishment" "Purifying Flame" "Reap" "Swordstorm" "Glacial Shield Swipe" "Seismic Trap" "Shattering Steel" "Shield Charge" "Shield Crush" "Shockwave Totem" "Shrapnel Ballista" "Snipe" "Spectral Shield Throw" "Split Arrow" "Splitting Steel" "Storm Burst" "Summon Carrion Golem" "Summon Reaper" "Summon Stone Golem" "Holy Sweep" "Tornado" "Trauma Support" "Unearth" "Vaal Absolution" "Vaal Animate Weapon" "Vaal Blade Flurry" "Vaal Blade Vortex" "Vaal Cleave" "Vaal Cyclone" "Vaal Double Strike" "Vaal Molten Shell" "Vaal Reap" "Crushing Fist" "Vicious Projectiles Support" "Void Sphere" "Vulnerability" "War Banner" "Wave of Conviction" "Withering Touch Support"
 #	SetBackgroundColor 180 0 0
 #	SetBorderColor 0 0 0
 #	SetTextColor 0 0 0
@@ -4268,6 +4268,16 @@ Show
 	DisableDropSound
 
 Show
+	BaseType "Volatile Vaal Orb" "Flesh of Xesht"
+	SetBackgroundColor 240 0 200
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	PlayAlertSound 10 250
+	SetFontSize 45
+	MinimapIcon 1 Pink Circle
+	PlayEffect Pink
+	DisableDropSound
+Show
 	BaseType "Orb of Binding" "Veiled" "Enkindling Orb" "Instilling Orb" "Oil Extractor"
 	Class "Currency"
 	SetBackgroundColor 0 225 125
@@ -4344,6 +4354,68 @@ Show
 	SetFontSize 38
 	AreaLevel <= 78
 	
+
+#3.28 New Currencies
+Show
+	BaseType "Coin of Knowledge" "Coin of Power" "Coin of Skill" "Coin of Restoration" "Coin of Desecration"
+	Class Currency
+	SetBackgroundColor 0 225 125
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 100
+	MinimapIcon 2 Green Circle
+	PlayEffect Green Temp
+	DisableDropSound
+Show
+	BaseType "Refracting Fog" "Essence of Desolation" "Crystallised Rancour"
+	Class Currency
+	SetBackgroundColor 0 185 185
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 125
+	MinimapIcon 2 Cyan Circle
+	DisableDropSound
+Show
+	BaseType "Sinistral Catalyst" "Dextral Catalyst"
+	Class Currency
+	SetBackgroundColor 0 225 125
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 100
+	MinimapIcon 2 Green Circle
+	PlayEffect Green Temp
+	DisableDropSound
+Show
+	BaseType "Memory of Trauma" "Memory of Reverence" "Memory of Loneliness"
+	Class Currency
+	SetBackgroundColor 0 185 185
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 125
+	MinimapIcon 2 Cyan Circle
+	DisableDropSound
+Show
+	BaseType "Runegraft"
+	Class Currency
+	SetBackgroundColor 170 158 130
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+Show
+	BaseType "Astrolabe"
+	Class Currency
+	SetBackgroundColor 0 225 125
+	SetBorderColor 0 0 0
+	SetTextColor 0 0 0
+	SetFontSize 45
+	PlayAlertSound 3 100
+	MinimapIcon 2 Green Circle
+	PlayEffect Green Temp
+	DisableDropSound
 #6L Blocks - located up here due to code priority issues. 5L and 6S blocks are in the Sockets section (7)
 #corrupted catcher
 Show
@@ -5558,15 +5630,6 @@ Show
 	PlayAlertSound 11 200
 	MinimapIcon 1 Cyan Raindrop
 	PlayEffect Cyan Temp
-Show
-	BaseType "Time-light Scroll" "Fragmentation Scroll" "Deregulation Scroll" "Electroshock Scroll" "Haemocombustion Scroll" "Specularity Scroll"
-	SetBackgroundColor 250 40 0
-	SetBorderColor 250 250 250
-	SetTextColor 0 0 0
-	SetFontSize 45
-	PlayAlertSound 2 200
-	MinimapIcon 0 Orange Triangle
-	PlayEffect Orange
 Show
 	BaseType "Facetor's Lens"
 	SetBackgroundColor 0 200 240
@@ -8155,7 +8218,7 @@ Show
 
 #Dogshit Tier: Hidden in all filters, waste of a click to pick up. Same highlight as trash tier. Only the very worst get added here.
 Hide
-	BaseType == "The Carrion Crow" "The Surgeon" "The King's Blade" "The Lunaris Priestess" "The Metalsmith's Gift" "Lantador's Lost Love" "The Scholar" "The Sigil" "The Lover" "The Puzzle" "The Warden" "Rain Tempter" "Rain of Chaos" "Prosperity" "Struck By Lightning" "The Inoculated" "The Opulent" "The Scarred Meadow" "Destined to Crumble" "Thirst for Knowledge" "The Witch" "The Visionary" "The Sword King's Salute" "The Harvester" "Rats" "Might is Right" "The Adventuring Spirit"
+	BaseType == "The Carrion Crow" "The Surgeon" "The King's Blade" "The Lunaris Priestess" "The Metalsmith's Gift" "Lantador's Lost Love" "The Scholar" "The Sigil" "The Lover" "The Warden" "Rain Tempter" "Rain of Chaos" "Prosperity" "Struck By Lightning" "The Inoculated" "The Opulent" "The Scarred Meadow" "Destined to Crumble" "Thirst for Knowledge" "The Witch" "The Visionary" "The Sword King's Salute" "The Harvester" "Rats" "Might is Right" "The Adventuring Spirit"
 	Class "Divination Card"
 	SetBackgroundColor 110 160 210
 	SetBorderColor 0 0 0
@@ -12436,7 +12499,7 @@ Show
 ###################################################################################
 #top and rare gems
 Show
-	BaseType "Item Quantity" "Awakened"
+	BaseType "Item Quantity" "Awakened" "Exceptional"
 	Class "Gem"
 	SetBackgroundColor 250 250 250
 	SetBorderColor 0 0 0


### PR DESCRIPTION
- Added new currencies: Volatile Vaal Orb, Flesh of Xesht, Coins, Catalysts, Memories, Runegrafts, Astrolabes
- Added Exceptional support gems alongside Awakened in top gem tier
- Renamed Sweep to Holy Sweep, Lesser Multiple Projectiles to Multiple Projectiles Support
- Removed deleted items: Harbinger scrolls, Cartographer's Chisel, Engineer's Orb, various shards
- Removed deleted div cards: The Cheater, The Puzzle
- Cleaned up empty blocks from removed items